### PR TITLE
[breaking change: fix #550] moves away from global variables

### DIFF
--- a/widget/alsa.lua
+++ b/widget/alsa.lua
@@ -18,7 +18,7 @@ local function factory(args)
     args           = args or {}
     local alsa     = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 5
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     alsa.cmd           = args.cmd or "amixer"
     alsa.channel       = args.channel or "Master"
@@ -38,10 +38,9 @@ local function factory(args)
             local l,s = string.match(mixer, "([%d]+)%%.*%[([%l]*)")
             l = tonumber(l)
             if alsa.last.level ~= l or alsa.last.status ~= s then
-                volume_now = { level = l, status = s }
-                widget = alsa.widget
-                settings()
-                alsa.last = volume_now
+                alsa.now = { level = l, status = s }
+                settings(alsa.widget, alsa.now)
+                alsa.last = alsa.now
             end
         end)
     end

--- a/widget/alsabar.lua
+++ b/widget/alsabar.lua
@@ -33,7 +33,7 @@ local function factory(args)
     args             = args or {}
 
     local timeout    = args.timeout or 5
-    local settings   = args.settings or function() end
+    local settings   = args.settings or function(_, _) end
     local width      = args.width or 63
     local height     = args.height or 1
     local margins    = args.margins or 1
@@ -95,12 +95,12 @@ local function factory(args)
                     alsabar.bar.color = alsabar.colors.unmute
                 end
 
-                volume_now = {
+                alsabar.now = {
                     level  = alsabar._current_level,
                     status = alsabar._playback
                 }
 
-                settings()
+                settings(alsabar.bar, alsabar.now)
 
                 if type(callback) == "function" then callback() end
             end

--- a/widget/contrib/moc.lua
+++ b/widget/contrib/moc.lua
@@ -27,15 +27,15 @@ local function factory(args)
     local cover_size    = args.cover_size or 100
     local default_art   = args.default_art or ""
     local followtag     = args.followtag or false
-    local settings      = args.settings or function() end
+    local settings      = args.settings or function(_, _) end
 
-    moc_notification_preset = { title = "Now playing", timeout = 6 }
+    local moc_notification_preset = { title = "Now playing", timeout = 6 }
 
     helpers.set_map("current moc track", nil)
 
     function moc.update()
         helpers.async("mocp -i", function(f)
-            moc_now = {
+            moc.now = {
                 state   = "N/A",
                 file    = "N/A",
                 artist  = "N/A",
@@ -47,25 +47,24 @@ local function factory(args)
 
             for line in string.gmatch(f, "[^\n]+") do
                 for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
-                    if     k == "State"       then moc_now.state   = v
-                    elseif k == "File"        then moc_now.file    = v
-                    elseif k == "Artist"      then moc_now.artist  = escape_f(v)
-                    elseif k == "SongTitle"   then moc_now.title   = escape_f(v)
-                    elseif k == "Album"       then moc_now.album   = escape_f(v)
-                    elseif k == "CurrentTime" then moc_now.elapsed = escape_f(v)
-                    elseif k == "TotalTime"   then moc_now.total   = escape_f(v)
+                    if     k == "State"       then moc.now.state   = v
+                    elseif k == "File"        then moc.now.file    = v
+                    elseif k == "Artist"      then moc.now.artist  = escape_f(v)
+                    elseif k == "SongTitle"   then moc.now.title   = escape_f(v)
+                    elseif k == "Album"       then moc.now.album   = escape_f(v)
+                    elseif k == "CurrentTime" then moc.now.elapsed = escape_f(v)
+                    elseif k == "TotalTime"   then moc.now.total   = escape_f(v)
                     end
                 end
             end
 
-            moc_notification_preset.text = string.format("%s (%s) - %s\n%s", moc_now.artist,
-                                           moc_now.album, moc_now.total, moc_now.title)
-            widget = moc.widget
-            settings()
+            moc_notification_preset.text = string.format("%s (%s) - %s\n%s", moc.now.artist,
+                                           moc.now.album, moc.now.total, moc.now.title)
+            settings(moc.widget, moc.now)
 
-            if moc_now.state == "PLAY" then
-                if moc_now.title ~= helpers.get_map("current moc track") then
-                    helpers.set_map("current moc track", moc_now.title)
+            if moc.now.state == "PLAY" then
+                if moc.now.title ~= helpers.get_map("current moc track") then
+                    helpers.set_map("current moc track", moc.now.title)
 
                     if followtag then moc_notification_preset.screen = focused() end
 
@@ -76,14 +75,14 @@ local function factory(args)
                         replaces_id = moc.id,
                     }
 
-                    local path   = string.format("%s/%s", music_dir, string.match(moc_now.file, ".*/"))
+                    local path   = string.format("%s/%s", music_dir, string.match(moc.now.file, ".*/"))
                     local cover  = string.format("find '%s' -maxdepth 1 -type f | egrep -i -m1 '%s'", path, cover_pattern)
                     helpers.async({ shell, "-c", cover }, function(current_icon)
                         common.icon = current_icon:gsub("\n", "")
                         moc.id = naughty.notify(common).id
                     end)
                 end
-            elseif  moc_now.state ~= "PAUSE" then
+            elseif  moc.now.state ~= "PAUSE" then
                 helpers.set_map("current moc track", nil)
             end
         end)

--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -19,7 +19,7 @@ local function factory(args)
 
     local cpu      = { core = {}, widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 2
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     function cpu.update()
         -- Read the amount of time the CPUs have spent performing
@@ -60,11 +60,9 @@ local function factory(args)
             end
         end
 
-        cpu_now = cpu.core
-        cpu_now.usage = cpu_now[0].usage
-        widget = cpu.widget
-
-        settings()
+        cpu.now = cpu.core
+        cpu.now.usage = cpu.now[0].usage
+        settings(cpu.widget, cpu.now)
     end
 
     helpers.newtimer("cpu", timeout, cpu.update)

--- a/widget/mem.lua
+++ b/widget/mem.lua
@@ -18,29 +18,28 @@ local function factory(args)
 
     local mem      = { widget = args.widget or wibox.widget.textbox() }
     local timeout  = args.timeout or 2
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     function mem.update()
-        mem_now = {}
+        mem.now = {}
         for line in lines("/proc/meminfo") do
             for k, v in gmatch(line, "([%a]+):[%s]+([%d]+).+") do
-                if     k == "MemTotal"     then mem_now.total = floor(v / 1024 + 0.5)
-                elseif k == "MemFree"      then mem_now.free  = floor(v / 1024 + 0.5)
-                elseif k == "Buffers"      then mem_now.buf   = floor(v / 1024 + 0.5)
-                elseif k == "Cached"       then mem_now.cache = floor(v / 1024 + 0.5)
-                elseif k == "SwapTotal"    then mem_now.swap  = floor(v / 1024 + 0.5)
-                elseif k == "SwapFree"     then mem_now.swapf = floor(v / 1024 + 0.5)
-                elseif k == "SReclaimable" then mem_now.srec  = floor(v / 1024 + 0.5)
+                if     k == "MemTotal"     then mem.now.total = floor(v / 1024 + 0.5)
+                elseif k == "MemFree"      then mem.now.free  = floor(v / 1024 + 0.5)
+                elseif k == "Buffers"      then mem.now.buf   = floor(v / 1024 + 0.5)
+                elseif k == "Cached"       then mem.now.cache = floor(v / 1024 + 0.5)
+                elseif k == "SwapTotal"    then mem.now.swap  = floor(v / 1024 + 0.5)
+                elseif k == "SwapFree"     then mem.now.swapf = floor(v / 1024 + 0.5)
+                elseif k == "SReclaimable" then mem.now.srec  = floor(v / 1024 + 0.5)
                 end
             end
         end
 
-        mem_now.used = mem_now.total - mem_now.free - mem_now.buf - mem_now.cache - mem_now.srec
-        mem_now.swapused = mem_now.swap - mem_now.swapf
-        mem_now.perc = math.floor(mem_now.used / mem_now.total * 100)
+        mem.now.used = mem.now.total - mem.now.free - mem.now.buf - mem.now.cache - mem.now.srec
+        mem.now.swapused = mem.now.swap - mem.now.swapf
+        mem.now.perc = math.floor(mem.now.used / mem.now.total * 100)
 
-        widget = mem.widget
-        settings()
+        settings(mem.widget, mem.now)
     end
 
     helpers.newtimer("mem", timeout, mem.update)

--- a/widget/net.lua
+++ b/widget/net.lua
@@ -25,7 +25,7 @@ local function factory(args)
     local eth_state  = args.eth_state or "off"
     local screen     = args.screen or 1
     local format     = args.format or "%.1f"
-    local settings   = args.settings or function() end
+    local settings   = args.settings or function(_, _) end
 
     -- Compatibility with old API where iface was a string corresponding to 1 interface
     net.iface = (args.iface and (type(args.iface) == "string" and {args.iface}) or
@@ -42,7 +42,7 @@ local function factory(args)
 
     function net.update()
         -- These are the totals over all specified interfaces
-        net_now = {
+        net.now = {
             devices  = {},
             -- Bytes since last iteration
             sent     = 0,
@@ -61,8 +61,8 @@ local function factory(args)
             dev_now.sent     = (now_t - dev_before.last_t) / timeout / units
             dev_now.received = (now_r - dev_before.last_r) / timeout / units
 
-            net_now.sent     = net_now.sent + dev_now.sent
-            net_now.received = net_now.received + dev_now.received
+            net.now.sent     = net.now.sent + dev_now.sent
+            net.now.received = net.now.received + dev_now.received
 
             dev_now.sent     = string.format(format, dev_now.sent)
             dev_now.received = string.format(format, dev_now.received)
@@ -100,18 +100,17 @@ local function factory(args)
                 helpers.set_map(dev, true)
             end
 
-            net_now.carrier = dev_now.carrier
-            net_now.state = dev_now.state
-            net_now.devices[dev] = dev_now
-            -- net_now.sent and net_now.received will be
+            net.now.carrier = dev_now.carrier
+            net.now.state = dev_now.state
+            net.now.devices[dev] = dev_now
+            -- net.now.sent and net.now.received will be
             -- the totals across all specified devices
         end
 
-        net_now.sent = string.format(format, net_now.sent)
-        net_now.received = string.format(format, net_now.received)
+        net.now.sent_string = string.format(format, net.now.sent)
+        net.now.received_string = string.format(format, net.now.received)
 
-        widget = net.widget
-        settings()
+        settings(net.widget, net.now)
     end
 
     helpers.newtimer("network", timeout, net.update)

--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -19,34 +19,33 @@ local function factory(args)
 
     local pulse    = { widget = args.widget or wibox.widget.textbox(), device = "N/A" }
     local timeout  = args.timeout or 5
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     pulse.devicetype = args.devicetype or "sink"
-    pulse.cmd = args.cmd or "pacmd list-" .. pulse.devicetype .. "s | sed -n -e '/*/,$!d' -e '/index/p' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
+    pulse.cmd = args.cmd or string.format("pacmd list-%ss | sed -n -e '/*/,$!d' -e '/index/p' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'", pulse.devicetype)
 
     function pulse.update()
         helpers.async({ shell, "-c", type(pulse.cmd) == "string" and pulse.cmd or pulse.cmd() },
         function(s)
-            volume_now = {
+            pulse.now = {
                 index  = string.match(s, "index: (%S+)") or "N/A",
                 device = string.match(s, "device.string = \"(%S+)\"") or "N/A",
                 muted  = string.match(s, "muted: (%S+)") or "N/A"
             }
 
-            pulse.device = volume_now.index
+            pulse.device = pulse.now.index
 
             local ch = 1
-            volume_now.channel = {}
+            pulse.now.channel = {}
             for v in string.gmatch(s, ":.-(%d+)%%") do
-                volume_now.channel[ch] = v
+                pulse.now.channel[ch] = v
                 ch = ch + 1
             end
 
-            volume_now.left  = volume_now.channel[1] or "N/A"
-            volume_now.right = volume_now.channel[2] or "N/A"
+            pulse.now.left  = pulse.now.channel[1] or "N/A"
+            pulse.now.right = pulse.now.channel[2] or "N/A"
 
-            widget = pulse.widget
-            settings()
+            settings(pulse.widget, pulse.now)
         end)
     end
 

--- a/widget/sysload.lua
+++ b/widget/sysload.lua
@@ -16,19 +16,18 @@ local open, match = io.open, string.match
 local function factory(args)
     args           = args or {}
 
-    local sysload  = { widget = args.widget or wibox.widget.textbox() }
+    local sysload  = { widget = args.widget or wibox.widget.textbox(), now = {} }
     local timeout  = args.timeout or 2
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     function sysload.update()
         local f = open("/proc/loadavg")
         local ret = f:read("*all")
         f:close()
 
-        load_1, load_5, load_15 = match(ret, "([^%s]+) ([^%s]+) ([^%s]+)")
+        sysload.now[1], sysload.now[5], sysload.now[15] = match(ret, "([^%s]+) ([^%s]+) ([^%s]+)")
 
-        widget = sysload.widget
-        settings()
+        settings(sysload.widget, sysload.now)
     end
 
     helpers.newtimer("sysload", timeout, sysload.update)

--- a/widget/temp.lua
+++ b/widget/temp.lua
@@ -19,26 +19,25 @@ local function factory(args)
     local timeout  = args.timeout or 30
     local tempfile = args.tempfile or "/sys/devices/virtual/thermal/thermal_zone0/temp"
     local format   = args.format or "%.1f"
-    local settings = args.settings or function() end
+    local settings = args.settings or function(_, _) end
 
     function temp.update()
         helpers.async({"find", "/sys/devices", "-type", "f", "-name", "*temp*"}, function(f)
-            temp_now = {}
+            temp.now = {}
             local temp_fl, temp_value
             for t in f:gmatch("[^\n]+") do
                 temp_fl = helpers.first_line(t)
                 if temp_fl then
                     temp_value = tonumber(temp_fl)
-                    temp_now[t] = temp_value and temp_value/1e3 or temp_fl
+                    temp.now[t] = temp_value and temp_value/1e3 or temp_fl
                 end
             end
-            if temp_now[tempfile] then
-                coretemp_now = string.format(format, temp_now[tempfile])
+            if temp.now[tempfile] then
+                temp.now.coretemp = string.format(format, temp.now[tempfile])
             else
-                coretemp_now = "N/A"
+                temp.now.coretemp = "N/A"
             end
-            widget = temp.widget
-            settings()
+            settings(temp.widget, temp.now)
         end)
     end
 


### PR DESCRIPTION
- going forward, there are a couple of ways to access state from the settings callbacks
  - `settings` functions should always take in `widget` and `now` as the arguments.  so the signature is `settings = function(widget, now)`
  - use `foo.widget` and `foo.now` to access the awesome widget and current state (respectively) of `foo` widget
- weather has been done in #549
- sysload's state is now in a `now` table.  access the 1, 5 and 15 min load averages via `now[1]`, `now[5]`, and `now[15]`
- the bat and contrib/tp_smapi widgets have NOT been migrated as i do not have a laptop to verify behaviors